### PR TITLE
PODs and Parsers for Ocp1Command PDU

### DIFF
--- a/include/oca/OcaTypes.hxx
+++ b/include/oca/OcaTypes.hxx
@@ -1,0 +1,54 @@
+/*
+  Copyright (C) 2015 Guy Sherman, Shermann Innovations Limited
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+*/
+#ifndef __OCATYPES_HXX__
+#define __OCATYPES_HXX__
+
+// C++ Standard Headers
+
+
+// C Standard Headers
+#include <stdint.h>
+
+// Boost Headers
+
+
+// 3rd Party Headers
+
+
+// GTK Headers
+
+
+namespace oca
+{
+	typedef uint8_t OcaUint8;
+	typedef uint16_t OcaUint16;
+	typedef uint32_t OcaUint32;
+	typedef uint64_t OcaUint64;
+
+	typedef OcaUint32 OcaONo;
+
+	typedef struct
+	{
+			OcaUint16 treeLevel;
+			OcaUint16 methodIndex;
+	} OcaMethodId;
+
+}
+
+#endif // __OCATYPES_HXX__

--- a/src/Ocp1Command.cxx
+++ b/src/Ocp1Command.cxx
@@ -21,54 +21,51 @@
 
 
 // C Standard Headers
-#include <arpa/inet.h>
+
 
 // Boost Headers
-#include <boost/asio.hpp>
+
 
 // 3rd Party Headers
 
 
 // GTK Headers
 
-#include "Ocp1Header.hxx"
+#include <oca/OcaTypes.hxx>
+#include "Ocp1Parameters.hxx"
 
+#include "Ocp1Command.hxx"
 
 namespace oca
 {
 	namespace net
 	{
-		Ocp1Header::Ocp1Header()
-			:	protocolVersion(0), messageSize(0), messageType(OcaCmd), messageCount(0)
+		Ocp1Command::Ocp1Command() : commandSize(0), handle(0), targetONo(0)
 		{
 
 		}
 
-		Ocp1Header::Ocp1Header(uint16_t protocolVersion, uint32_t messageSize, OcaMessageType messageType, uint16_t messageCount)
-			:	protocolVersion(protocolVersion), messageSize(messageSize), messageType(messageType), messageCount(messageCount)
+		Ocp1Command::Ocp1Command(const Ocp1Command& rhs)
+		 : 	commandSize(rhs.commandSize),
+		 	handle(rhs.handle),
+		 	targetONo(rhs.targetONo),
+			methodId(rhs.methodId),
+			parameters(rhs.parameters)
 		{
 
 		}
 
-		Ocp1Header::Ocp1Header(const Ocp1Header& rhs)
-			:	protocolVersion(rhs.protocolVersion), messageSize(rhs.messageSize), messageType(rhs.messageType), messageCount(rhs.messageCount)
+		Ocp1Command& Ocp1Command::operator=(const Ocp1Command& rhs)
 		{
-
-		}
-
-		Ocp1Header& Ocp1Header::operator=(const Ocp1Header& rhs)
-		{
-			if (this != &rhs)
-			{
-				protocolVersion = rhs.protocolVersion;
-				messageSize = rhs.messageSize;
-				messageType = rhs.messageType;
-				messageCount = rhs.messageCount;
-			}
+			commandSize = rhs.commandSize;
+			handle = rhs.handle;
+			targetONo = rhs.targetONo;
+			methodId = rhs.methodId;
+			parameters = rhs.parameters;
 
 			return *this;
 		}
 
-		Ocp1Header::~Ocp1Header() {}
+		Ocp1Command::~Ocp1Command() {}
 	}
 }

--- a/src/Ocp1Command.cxx
+++ b/src/Ocp1Command.cxx
@@ -21,7 +21,7 @@
 
 
 // C Standard Headers
-
+#include <cstring>
 
 // Boost Headers
 
@@ -42,7 +42,7 @@ namespace oca
 	{
 		Ocp1Command::Ocp1Command() : commandSize(0), handle(0), targetONo(0)
 		{
-
+			memset(&methodId, 0, sizeof(OcaMethodId));
 		}
 
 		Ocp1Command::Ocp1Command(const Ocp1Command& rhs)

--- a/src/Ocp1Command.hxx
+++ b/src/Ocp1Command.hxx
@@ -1,0 +1,60 @@
+/*
+  Copyright (C) 2015 Guy Sherman, Shermann Innovations Limited
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+*/
+#ifndef __OCP1COMMAND_HXX__
+#define __OCP1COMMAND_HXX__
+
+// C++ Standard Headers
+
+
+// C Standard Headers
+
+
+// Boost Headers
+
+
+// 3rd Party Headers
+
+
+// GTK Headers
+
+#include <oca/OcaTypes.hxx>
+#include "Ocp1Parameters.hxx"
+
+namespace oca
+{
+	namespace net
+	{
+		struct Ocp1Command
+		{
+			Ocp1Command();
+			Ocp1Command(const Ocp1Command&);
+			Ocp1Command& operator=(const Ocp1Command&);
+			~Ocp1Command();
+
+
+			OcaUint32		commandSize;
+			OcaUint32		handle;
+			OcaONo			targetONo;
+			OcaMethodId 	methodId;
+			Ocp1Parameters	parameters;
+		};
+	}
+}
+
+#endif // __OCP1COMMAND_HXX__

--- a/src/Ocp1Command.hxx
+++ b/src/Ocp1Command.hxx
@@ -20,7 +20,7 @@
 #define __OCP1COMMAND_HXX__
 
 // C++ Standard Headers
-
+#include <vector>
 
 // C Standard Headers
 
@@ -54,6 +54,8 @@ namespace oca
 			OcaMethodId 	methodId;
 			Ocp1Parameters	parameters;
 		};
+
+		typedef std::vector<Ocp1Command> CommandList;
 	}
 }
 

--- a/src/Ocp1Parameters.cxx
+++ b/src/Ocp1Parameters.cxx
@@ -21,54 +21,39 @@
 
 
 // C Standard Headers
-#include <arpa/inet.h>
+
 
 // Boost Headers
-#include <boost/asio.hpp>
+
 
 // 3rd Party Headers
 
 
 // GTK Headers
 
-#include "Ocp1Header.hxx"
+#include <oca/OcaTypes.hxx>
 
+#include "Ocp1Parameters.hxx"
 
 namespace oca
 {
 	namespace net
 	{
-		Ocp1Header::Ocp1Header()
-			:	protocolVersion(0), messageSize(0), messageType(OcaCmd), messageCount(0)
+		Ocp1Parameters::Ocp1Parameters() : parameterCount(0) {}
+
+		Ocp1Parameters::Ocp1Parameters(const Ocp1Parameters& rhs) : parameterCount(rhs.parameterCount), parameters(rhs.parameters)	{}
+
+		Ocp1Parameters& Ocp1Parameters::operator=(const Ocp1Parameters& rhs)
 		{
-
-		}
-
-		Ocp1Header::Ocp1Header(uint16_t protocolVersion, uint32_t messageSize, OcaMessageType messageType, uint16_t messageCount)
-			:	protocolVersion(protocolVersion), messageSize(messageSize), messageType(messageType), messageCount(messageCount)
-		{
-
-		}
-
-		Ocp1Header::Ocp1Header(const Ocp1Header& rhs)
-			:	protocolVersion(rhs.protocolVersion), messageSize(rhs.messageSize), messageType(rhs.messageType), messageCount(rhs.messageCount)
-		{
-
-		}
-
-		Ocp1Header& Ocp1Header::operator=(const Ocp1Header& rhs)
-		{
-			if (this != &rhs)
-			{
-				protocolVersion = rhs.protocolVersion;
-				messageSize = rhs.messageSize;
-				messageType = rhs.messageType;
-				messageCount = rhs.messageCount;
-			}
+			this->parameterCount = rhs.parameterCount;
+			this->parameters = rhs.parameters;
 
 			return *this;
 		}
 
-		Ocp1Header::~Ocp1Header() {}
+		Ocp1Parameters::~Ocp1Parameters()
+		{
+
+		}
 	}
 }

--- a/src/Ocp1Parameters.hxx
+++ b/src/Ocp1Parameters.hxx
@@ -1,0 +1,61 @@
+/*
+  Copyright (C) 2015 Guy Sherman, Shermann Innovations Limited
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+*/
+#ifndef __OCP1PARAMETERS_HXX__
+#define __OCP1PARAMETERS_HXX__
+
+// C++ Standard Headers
+#include <vector>
+
+// C Standard Headers
+
+
+// Boost Headers
+
+
+// 3rd Party Headers
+
+
+// GTK Headers
+
+
+#include <oca/OcaTypes.hxx>
+
+namespace oca
+{
+    namespace net
+    {
+        // Notably, this class does not decode the parameters, it simply wraps them,
+        // It is up to the object executing the command to decode the parameters
+        struct Ocp1Parameters
+        {
+
+            Ocp1Parameters();
+            Ocp1Parameters(const Ocp1Parameters&);
+
+            Ocp1Parameters& operator=(const Ocp1Parameters&);
+
+            ~Ocp1Parameters();
+
+            OcaUint8    parameterCount;             // the number of parameters, not the number of bytes below
+            std::vector<OcaUint8>   parameters;    // Hence we use a vector, because managing raw arrays sucks.
+        };
+    }
+}
+
+#endif // __OCP1PARAMETERS_HXX__

--- a/src/OcpMessageReader.hxx
+++ b/src/OcpMessageReader.hxx
@@ -21,6 +21,7 @@
 
     // C++ Standard Headers
     #include <map>
+    #include <vector>
 
     // C Standard Headers
 
@@ -38,6 +39,7 @@
     // GTK Headers
     #include "Ocp1Header.hxx"
     #include "Ocp1Parameters.hxx"
+    #include "Ocp1Command.hxx"
 
 	namespace oca
 	{
@@ -53,6 +55,11 @@
 			static void HeaderFromBuffer(boost::asio::const_buffer& buffer, net::Ocp1Header& header);
 
             static void ParametersFromBuffer(boost::asio::const_buffer& buffer, size_t remainingCommandBytes, net::Ocp1Parameters& parameters);
+
+            static void MethodIdFromBuffer(boost::asio::const_buffer& buffer, OcaMethodId& methodId);
+
+            static void CommandFromBuffer(boost::asio::const_buffer& buffer, net::Ocp1Command& cmd);
+            static void CommandListFromBuffer(boost::asio::const_buffer& buffer, net::Ocp1Header header, std::vector<net::Ocp1Command>& commands);
 
             virtual void SyncValueReceived(uint8_t* bufferData, const boost::system::error_code& error, size_t bytesTransferred, boost::function<void(void)> getHeader);
 

--- a/src/OcpMessageReader.hxx
+++ b/src/OcpMessageReader.hxx
@@ -37,6 +37,7 @@
 
     // GTK Headers
     #include "Ocp1Header.hxx"
+    #include "Ocp1Parameters.hxx"
 
 	namespace oca
 	{
@@ -48,8 +49,10 @@
             OcpMessageReader();
             virtual ~OcpMessageReader();
 
-            static const net::Ocp1Header FromBuffer(boost::asio::const_buffer& buffer);	// TODO: should the parameter be const? I don't think so, but I don't know for sure.
-			static void FromBuffer(boost::asio::const_buffer& buffer, net::Ocp1Header& header);
+            static const net::Ocp1Header HeaderFromBuffer(boost::asio::const_buffer& buffer);	// TODO: should the parameter be const? I don't think so, but I don't know for sure.
+			static void HeaderFromBuffer(boost::asio::const_buffer& buffer, net::Ocp1Header& header);
+
+            static void ParametersFromBuffer(boost::asio::const_buffer& buffer, size_t remainingCommandBytes, net::Ocp1Parameters& parameters);
 
             virtual void SyncValueReceived(uint8_t* bufferData, const boost::system::error_code& error, size_t bytesTransferred, boost::function<void(void)> getHeader);
 
@@ -58,18 +61,7 @@
             virtual void Ocp1DataReceived(uint8_t* bufferData, uint64_t connectionIdentifier, const boost::system::error_code& error, size_t bytesTransferred);
 
         private:
-            // TODO: it goes against my better judgement to have this here.
-            // Since there is currently only one OcpMessageReader per OcaNetwork
-            // this is actually a bug if there is more than one TcpConnection, ie
-            // this class was supposed to be stateless, but I don't really want the
-            // TcpConnection to be concerned with the details of the Ocp1Header and I need
-            // to keep the header around between Ocp1HeaderReceived and Ocp1DataReceived
-            // The solution could be to make a factory for this as well, so that we can
-            // have one per connection, without tightly coupling the connection and this
-            // class; or, I could make this a map of <TcpConnection*, Ocp1Header> so that the state
-            // is stored per connection. I like the latter more. The third option is to pass a callback
-            // when calling the callback, but that just feels like the code would be hard to read.
-            //oca::net::Ocp1Header header;
+
             typedef std::map<uint64_t, oca::net::Ocp1Header> ConnectionStateMap;
             ConnectionStateMap perConnectionState;
 		};

--- a/src/OcpMessageWriter.cxx
+++ b/src/OcpMessageWriter.cxx
@@ -31,7 +31,13 @@
 
 // GTK Headers
 
+
+#include <oca/OcaTypes.hxx>
+#include "Ocp1Header.hxx"
+#include "Ocp1Parameters.hxx"
+
 #include "OcpMessageWriter.hxx"
+
 
 
 namespace oca
@@ -56,5 +62,17 @@ namespace oca
 			boost::asio::mutable_buffer bmc = bmt+sizeof(uint8_t);
 			uint16_t* mc = boost::asio::buffer_cast<uint16_t*>(bmc);
 			*mc = htons(header.messageCount);
+		}
+
+		void OcpMessageWriter::WriteParametersToBuffer(const net::Ocp1Parameters& parameters, boost::asio::mutable_buffer& buffer)
+		{
+			OcaUint8* pc = boost::asio::buffer_cast<OcaUint8*>(buffer);
+			*pc = parameters.parameterCount;
+
+			// TODO: there's a bit of a security issue here: we trust that the buffer has enough space #security
+			boost::asio::mutable_buffer paramBuffer = buffer + sizeof(OcaUint8);
+			OcaUint8* destination = boost::asio::buffer_cast<OcaUint8*>(paramBuffer);
+			memcpy(destination, &parameters.parameters[0], parameters.parameters.size());
+
 		}
 }

--- a/src/OcpMessageWriter.hxx
+++ b/src/OcpMessageWriter.hxx
@@ -20,7 +20,7 @@
 #define __OCP1MESSAGEWRITER_HXX__
 
 // C++ Standard Headers
-
+#include <vector>
 
 // C Standard Headers
 
@@ -36,15 +36,26 @@
 
 #include "Ocp1Header.hxx"
 #include "Ocp1Parameters.hxx"
+#include "Ocp1Command.hxx"
 
 namespace oca
 {
+
 		class OcpMessageWriter : public boost::enable_shared_from_this<OcpMessageWriter>
 		{
 		public:
+
 			static void WriteHeaderToBuffer(const net::Ocp1Header& header, boost::asio::mutable_buffer& buffer);
 
 			static void WriteParametersToBuffer(const net::Ocp1Parameters& parameters, boost::asio::mutable_buffer& buffer);
+
+			static void WriteMethodIdToBuffer(const OcaMethodId& id, boost::asio::mutable_buffer& buffer);
+
+			static void WriteCommandToBuffer(const net::Ocp1Command& command, boost::asio::mutable_buffer& buffer);
+
+			static OcaUint32 ComputeCommandDataSize(net::Ocp1Command& command);
+			static OcaUint32 ComputeCommandListDataSize(net::CommandList& commands);
+
 		};
 }
 

--- a/src/OcpMessageWriter.hxx
+++ b/src/OcpMessageWriter.hxx
@@ -35,6 +35,7 @@
 // GTK Headers
 
 #include "Ocp1Header.hxx"
+#include "Ocp1Parameters.hxx"
 
 namespace oca
 {
@@ -42,6 +43,8 @@ namespace oca
 		{
 		public:
 			static void WriteHeaderToBuffer(const net::Ocp1Header& header, boost::asio::mutable_buffer& buffer);
+
+			static void WriteParametersToBuffer(const net::Ocp1Parameters& parameters, boost::asio::mutable_buffer& buffer);
 		};
 }
 

--- a/tests/test_OcpMessageReader.cxx
+++ b/tests/test_OcpMessageReader.cxx
@@ -162,17 +162,36 @@ TEST(Suite_OcpMessageReader, SyncValueReceived_GetHeaderNotCalledForErrCode)
 	EXPECT_EQ(false, cbc.fired);
 }
 
-TEST(Suite_OcpMessageReader, FromBuffer)
+TEST(Suite_OcpMessageReader, HeaderFromBuffer)
 {
 	const uint8_t testData[16] = {0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 	boost::asio::const_buffer buf(testData, 16);
 
-	const oca::net::Ocp1Header header = oca::OcpMessageReader::FromBuffer(buf);
+	const oca::net::Ocp1Header header = oca::OcpMessageReader::HeaderFromBuffer(buf);
 
 	EXPECT_EQ(1, header.protocolVersion);
 	EXPECT_EQ(2, header.messageSize);
 	EXPECT_EQ(oca::net::OcaCmdRrq, (oca::net::OcaMessageType)header.messageType);
 	EXPECT_EQ(1, header.messageCount);
+
+
+}
+
+TEST(Suite_OcpMessageReader, ParametersFromBuffer)
+{
+	const uint8_t testData[16] = {0x04, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04 };
+	boost::asio::const_buffer buf(testData, 16);
+
+	oca::net::Ocp1Parameters params;
+	oca::OcpMessageReader::ParametersFromBuffer(buf, 16, params);
+
+	EXPECT_EQ(4, params.parameterCount);
+	EXPECT_EQ(15, params.parameters.size());
+	EXPECT_EQ(1, params.parameters.at(0));
+	EXPECT_EQ(2, params.parameters.at(2));
+	EXPECT_EQ(3, params.parameters.at(6));
+	EXPECT_EQ(4, params.parameters.at(14));
+
 
 
 }

--- a/tests/test_OcpMessageWriter.cxx
+++ b/tests/test_OcpMessageWriter.cxx
@@ -32,10 +32,11 @@
 // GTK Headers
 
 
-
+#include <oca/OcaTypes.hxx>
 #include <OcpMessageWriter.hxx>
 #include <Ocp1Header.hxx>
 #include <Ocp1Parameters.hxx>
+#include <Ocp1Command.hxx>
 
 TEST(Suite_OcpMessageWriter, WriteHeaderToBuffer)
 {
@@ -77,4 +78,128 @@ TEST(Suite_OcpMessageWriter, WriteParametersToBuffer)
 	EXPECT_EQ(testData[1], 0x00);
 	EXPECT_EQ(testData[2], 0x01);
 	EXPECT_EQ(testData[3], 0x02);
+}
+
+TEST(Suite_OcpMessageWriter, WriteMethodIdToBuffer)
+{
+	oca::OcaMethodId id;
+	memset(&id, 0, sizeof(oca::OcaMethodId));
+	id.treeLevel = 0xDEAD;
+	id.methodIndex = 0xF00D;
+
+	uint8_t testData[64];
+	memset(&testData[0], 0, 64);
+
+	boost::asio::mutable_buffer buf(testData, 64);
+
+	oca::OcpMessageWriter::WriteMethodIdToBuffer(id, buf);
+
+	EXPECT_EQ(testData[0], 0xDE);
+	EXPECT_EQ(testData[1], 0xAD);
+	EXPECT_EQ(testData[2], 0xF0);
+	EXPECT_EQ(testData[3], 0x0D);
+}
+
+TEST(Suite_OcpMessageWriter, WriteCommandToBuffer)
+{
+	oca::net::Ocp1Parameters params;
+	params.parameterCount = 3;
+	params.parameters.push_back(0);
+	params.parameters.push_back(1);
+	params.parameters.push_back(2);
+
+	oca::OcaMethodId id;
+	memset(&id, 0, sizeof(oca::OcaMethodId));
+	id.treeLevel = 0x0102;
+	id.methodIndex = 0x0304;
+
+	uint8_t testData[1024];
+	memset(&testData[0], 0, 1024);
+
+	boost::asio::mutable_buffer buf(testData, 1024);
+
+	oca::net::Ocp1Command cmd;
+	cmd.commandSize = 20;
+	cmd.handle = 0xDEADF00D;
+	cmd.targetONo = 0xC01DBEEF;
+	cmd.methodId = id;
+	cmd.parameters = params;
+
+	oca::OcpMessageWriter::WriteCommandToBuffer(cmd, buf);
+
+	EXPECT_EQ(0x14, testData[3]);
+	EXPECT_EQ(0x0D, testData[7]);
+	EXPECT_EQ(0xEF, testData[11]);
+	EXPECT_EQ(0x04, testData[15]);
+	EXPECT_EQ(0x03, testData[16]);
+
+}
+
+TEST(Suite_OcpMessageWriter, ComputeCommandDataSize)
+{
+	oca::net::Ocp1Parameters params;
+	params.parameterCount = 3;
+	params.parameters.push_back(0);
+	params.parameters.push_back(1);
+	params.parameters.push_back(2);
+
+	oca::OcaMethodId id;
+	memset(&id, 0, sizeof(oca::OcaMethodId));
+	id.treeLevel = 0x0102;
+	id.methodIndex = 0x0304;
+
+	uint8_t testData[1024];
+	memset(&testData[0], 0, 1024);
+
+	boost::asio::mutable_buffer buf(testData, 1024);
+
+	oca::net::Ocp1Command cmd;
+	cmd.commandSize = 0;
+	cmd.handle = 0xDEADF00D;
+	cmd.targetONo = 0xC01DBEEF;
+	cmd.methodId = id;
+	cmd.parameters = params;
+
+
+	oca::OcaUint32 commandDataSize = oca::OcpMessageWriter::ComputeCommandDataSize(cmd);
+
+	EXPECT_EQ(20, commandDataSize);
+	EXPECT_EQ(20, cmd.commandSize);
+
+}
+
+TEST(Suite_OcpMessageWriter, ComputeCommandListDataSize)
+{
+	oca::net::Ocp1Parameters params;
+	params.parameterCount = 3;
+	params.parameters.push_back(0);
+	params.parameters.push_back(1);
+	params.parameters.push_back(2);
+
+	oca::OcaMethodId id;
+	memset(&id, 0, sizeof(oca::OcaMethodId));
+	id.treeLevel = 0x0102;
+	id.methodIndex = 0x0304;
+
+	uint8_t testData[1024];
+	memset(&testData[0], 0, 1024);
+
+	boost::asio::mutable_buffer buf(testData, 1024);
+
+	oca::net::Ocp1Command cmd;
+	cmd.commandSize = 0;
+	cmd.handle = 0xDEADF00D;
+	cmd.targetONo = 0xC01DBEEF;
+	cmd.methodId = id;
+	cmd.parameters = params;
+
+
+	std::vector<oca::net::Ocp1Command> commands;
+	commands.push_back(cmd);
+	commands.push_back(cmd);
+
+	oca::OcaUint32 commandListDataSize = oca::OcpMessageWriter::ComputeCommandListDataSize(commands);
+
+	EXPECT_EQ(40, commandListDataSize);
+
 }

--- a/tests/test_OcpMessageWriter.cxx
+++ b/tests/test_OcpMessageWriter.cxx
@@ -35,6 +35,7 @@
 
 #include <OcpMessageWriter.hxx>
 #include <Ocp1Header.hxx>
+#include <Ocp1Parameters.hxx>
 
 TEST(Suite_OcpMessageWriter, WriteHeaderToBuffer)
 {
@@ -55,4 +56,25 @@ TEST(Suite_OcpMessageWriter, WriteHeaderToBuffer)
 	EXPECT_EQ(testData[5], 0x02);
 	EXPECT_EQ(testData[6], 0x01);
 	EXPECT_EQ(testData[8], 0x01);
+}
+
+TEST(Suite_OcpMessageWriter, WriteParametersToBuffer)
+{
+	oca::net::Ocp1Parameters params;
+	params.parameterCount = 3;
+	params.parameters.push_back(0);
+	params.parameters.push_back(1);
+	params.parameters.push_back(2);
+
+	uint8_t testData[64];
+	memset(&testData[0], 0, 64);
+
+	boost::asio::mutable_buffer buf(testData, 32);
+
+	oca::OcpMessageWriter::WriteParametersToBuffer(params, buf);
+
+	EXPECT_EQ(testData[0], 0x03);
+	EXPECT_EQ(testData[1], 0x00);
+	EXPECT_EQ(testData[2], 0x01);
+	EXPECT_EQ(testData[3], 0x02);
 }


### PR DESCRIPTION
Added necessary OCA/OCP types for the Ocp1Command PDU.

Added code to read/write from/to a memory buffer.

Added tests for the above.