### PR TITLE
Added writers for Ocp1Response and for list of Ocp1Command

### DIFF
--- a/src/Ocp1Response.hxx
+++ b/src/Ocp1Response.hxx
@@ -20,6 +20,7 @@
 #define __OCP1RESPONSE_HXX__
 
 // C++ Standard Headers
+#include <vector>
 
 // C Standard Headers
 
@@ -54,6 +55,8 @@ namespace oca
 			Ocp1Parameters		parameters;
 
 		};
+
+		typedef std::vector<Ocp1Response> ResponseList;
 	}
 }
 

--- a/src/OcpMessageWriter.hxx
+++ b/src/OcpMessageWriter.hxx
@@ -37,6 +37,7 @@
 #include "Ocp1Header.hxx"
 #include "Ocp1Parameters.hxx"
 #include "Ocp1Command.hxx"
+#include "Ocp1Response.hxx"
 
 namespace oca
 {
@@ -47,14 +48,21 @@ namespace oca
 
 			static void WriteHeaderToBuffer(const net::Ocp1Header& header, boost::asio::mutable_buffer& buffer);
 
+			static void WriteCommandListToBuffer(oca::net::CommandList const& commands, boost::asio::mutable_buffer& buffer);
+			static void WriteCommandToBuffer(const net::Ocp1Command& command, boost::asio::mutable_buffer& buffer);
+			static void WriteMethodIdToBuffer(const OcaMethodId& id, boost::asio::mutable_buffer& buffer);
 			static void WriteParametersToBuffer(const net::Ocp1Parameters& parameters, boost::asio::mutable_buffer& buffer);
 
-			static void WriteMethodIdToBuffer(const OcaMethodId& id, boost::asio::mutable_buffer& buffer);
+			static void WriteResponseListToBuffer(oca::net::ResponseList const& responses, boost::asio::mutable_buffer& buffer);
+			static void WriteResponseToBuffer(const net::Ocp1Response& response, boost::asio::mutable_buffer& buffer);
 
-			static void WriteCommandToBuffer(const net::Ocp1Command& command, boost::asio::mutable_buffer& buffer);
+
 
 			static OcaUint32 ComputeCommandDataSize(net::Ocp1Command& command);
 			static OcaUint32 ComputeCommandListDataSize(net::CommandList& commands);
+
+			static OcaUint32 ComputeResponseDataSize(net::Ocp1Response& response);
+			static OcaUint32 ComputeResponseListDataSize(net::ResponseList& responses);
 
 		};
 }


### PR DESCRIPTION
Also tidied up some places where we were iterating std::vector with
traditional for loops instead of using iterators.