### PR TITLE
Develop keep alive

### DIFF
--- a/include/oca/OcaNetwork.hxx
+++ b/include/oca/OcaNetwork.hxx
@@ -33,11 +33,17 @@
 
 // GTK Headers
 
+
+// Our headers
+
+
 namespace oca
 {
     namespace net
     {
         class TcpServer;
+        class OcpSessionFactory;
+        class ITcpConnection;
     }
 
     class OcaNetwork
@@ -53,6 +59,9 @@ namespace oca
         OcaNetwork(const OcaNetwork& rhs);
         OcaNetwork& operator=(const OcaNetwork& rhs);
 
+        void newConnectionCreated(boost::shared_ptr<oca::net::ITcpConnection> connection);
+
+        boost::shared_ptr<oca::net::OcpSessionFactory> sessionFactory;
         boost::shared_ptr<oca::net::TcpServer> tcpServer;
         bool isRunning;
     };

--- a/include/oca/OcaNetwork.hxx
+++ b/include/oca/OcaNetwork.hxx
@@ -59,7 +59,7 @@ namespace oca
         OcaNetwork(const OcaNetwork& rhs);
         OcaNetwork& operator=(const OcaNetwork& rhs);
 
-        void newConnectionCreated(boost::shared_ptr<oca::net::ITcpConnection> connection);
+        static void newConnectionCreated(boost::shared_ptr<oca::net::ITcpConnection> connection);
 
         boost::shared_ptr<oca::net::OcpSessionFactory> sessionFactory;
         boost::shared_ptr<oca::net::TcpServer> tcpServer;

--- a/src/OcaNetwork.cxx
+++ b/src/OcaNetwork.cxx
@@ -72,7 +72,6 @@ namespace oca
                 port,
                 boost::bind(
                     &OcaNetwork::newConnectionCreated,
-                    this,
                     _1
                 )
             )

--- a/src/OcpSessionFactory.cxx
+++ b/src/OcpSessionFactory.cxx
@@ -48,7 +48,7 @@ namespace oca
 
 		OcpSessionFactory::~OcpSessionFactory() {}
 
-		boost::shared_ptr<IOcpSession> OcpSessionFactory::CreateSession(ITcpConnection::pointer tcpConnection)
+		boost::shared_ptr<IOcpSession> OcpSessionFactory::CreateSession()
 		{
 			return boost::shared_ptr<IOcpSession>(new OcpSession());
 		}

--- a/src/OcpSessionFactory.hxx
+++ b/src/OcpSessionFactory.hxx
@@ -16,8 +16,8 @@
   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 */
-#ifndef __TCPCONNECTIONFACTORY_HXX_
-#define __TCPCONNECTIONFACTORY_HXX_
+#ifndef __OCPSESSIONFACTORY_HXX__
+#define __OCPSESSIONFACTORY_HXX__
 
 // C++ Standard Headers
 
@@ -51,11 +51,11 @@ namespace oca
 			OcpSessionFactory();
 			virtual ~OcpSessionFactory();
 
-			virtual boost::shared_ptr<IOcpSession> CreateSession(boost::shared_ptr<ITcpConnection> tcpConnection);
+			virtual boost::shared_ptr<IOcpSession> CreateSession();
 
 		};
 	}
 }
 
 
-#endif // __TCPCONNECTIONFACTORY_HXX_
+#endif // __OCPSESSIONFACTORY_HXX__

--- a/src/TcpConnectionFactory.hxx
+++ b/src/TcpConnectionFactory.hxx
@@ -35,11 +35,9 @@
 // GTK Headers
 
 // Our Headers
-#include "OcpSession.hxx"
 
 namespace oca
 {
-	class OcpMessageReader;
 
 	namespace net
 	{

--- a/src/TcpServer.cxx
+++ b/src/TcpServer.cxx
@@ -25,6 +25,7 @@
 
 // Boost Headers
 #include <boost/shared_ptr.hpp>
+#include <boost/function.hpp>
 #include <boost/bind.hpp>
 #include <boost/asio.hpp>
 
@@ -42,8 +43,17 @@ namespace oca
 {
     namespace net
     {
-        TcpServer::TcpServer(boost::shared_ptr<TcpConnectionFactory> connectionFactory, boost::shared_ptr<boost::asio::io_service> ioService, uint16_t port)
-            : acceptor(*ioService, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port)), connectionFactory(connectionFactory), ioService(ioService), port(port), isRunning(false)
+        TcpServer::TcpServer(
+            boost::shared_ptr<TcpConnectionFactory> connectionFactory,
+            boost::shared_ptr<boost::asio::io_service> ioService,
+            uint16_t port,
+            ConnectionEventHandler handler)
+            : acceptor(*ioService, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port)),
+            connectionFactory(connectionFactory),
+            ioService(ioService),
+            port(port),
+            isRunning(false),
+            handler(handler)
         {
             accept();
         }
@@ -69,6 +79,7 @@ namespace oca
 
         void TcpServer::accepted(boost::shared_ptr<ITcpConnection> connection, const boost::system::error_code &error)
         {
+            handler(connection);
             if (!error)
             {
                 connection->Start();
@@ -97,7 +108,7 @@ namespace oca
 
         TcpServer::~TcpServer()
         {
-            
+
         }
     }
 }

--- a/src/TcpServer.hxx
+++ b/src/TcpServer.hxx
@@ -26,7 +26,9 @@
 
 
     // Boost Headers
-	#include <boost/shared_ptr.hpp>
+    #include <boost/function.hpp>
+    #include <boost/bind.hpp>
+    #include <boost/shared_ptr.hpp>
 	#include <boost/asio.hpp>
 
     // 3rd Party Headers
@@ -34,19 +36,26 @@
 
     // GTK Headers
 
+// Our Headers
 
+#include "TcpConnectionFactory.hxx"
+#include "ITcpConnection.hxx"
 
 namespace oca
 {
 	namespace net
 	{
-		class ITcpConnection;
-        class TcpConnectionFactory;
 
 		class TcpServer
 		{
 		public:
-			TcpServer(boost::shared_ptr<TcpConnectionFactory> connectionFactory, boost::shared_ptr<boost::asio::io_service> ioService, uint16_t port);
+			typedef boost::function< void(boost::shared_ptr<ITcpConnection>) > ConnectionEventHandler;
+
+            TcpServer(
+                boost::shared_ptr<oca::net::TcpConnectionFactory> connectionFactory,
+                boost::shared_ptr<boost::asio::io_service> ioService,
+                uint16_t port,
+                ConnectionEventHandler handler);
             void Start();
             void Stop();
 			virtual ~TcpServer();
@@ -62,6 +71,7 @@ namespace oca
             boost::shared_ptr<boost::asio::io_service> ioService;
             uint16_t port;
             bool isRunning;
+            ConnectionEventHandler handler;
 
 		};
 	}


### PR DESCRIPTION
Added functionality to allow the OcaNetwork object to observe the creation of new TcpConnection objects (which happens when new clients connect).